### PR TITLE
Instructions should say 'gonk-misc', not 'gonzo-misc'

### DIFF
--- a/device-list.html
+++ b/device-list.html
@@ -66,7 +66,7 @@ title:     Device List - JanOS
 &lt;remote name="jan-os" fetch="git://github.com/jan-os/" /&gt;
 </code></pre>
   <p>
-    Then find the lines for all projects with name 'gaia'; 'gecko'; 'gonzo-misc',
+    Then find the lines for all projects with name 'gaia'; 'gecko'; 'gonk-misc',
     and remove them. In their place add:
   </p>
   <pre><code class="language-markup">


### PR DESCRIPTION
At least, I'm pretty sure that's what you meant. Too many 'g' product names!